### PR TITLE
On android pthread is built into libc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,11 @@ if(BUILD_TESTER)
   add_dependencies(tester mixed_shared)
   set_property(TARGET tester PROPERTY C_STANDARD 99)
   target_compile_options(tester PRIVATE ${COMPILATION_FLAGS})
-  target_link_libraries(tester mixed_shared pthread)
+  if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
+    target_link_libraries(tester mixed_shared)
+  else()
+    target_link_libraries(tester mixed_shared pthread)
+  endif()
 
   add_custom_target(run_tests
     COMMAND "${CMAKE_BINARY_DIR}/tester"


### PR DESCRIPTION
Fixes cmake build for android.
`pthread` is built into `libc`, so the build fails if you try to link against it. (See https://developer.android.com/ndk/guides/stable_apis#c_library .)

The tester program can't be built though, since `pthread_cancel` is not implemented on android.