### PR TITLE
More consistent argument type in mixed_make_segment_generator.

### DIFF
--- a/src/mixed.h
+++ b/src/mixed.h
@@ -1067,7 +1067,7 @@ extern "C" {
   /// frequency and wave form type. You may change the frequency and
   /// wave form type at any time. Potentially this could be used to
   /// create a very primitive synthesizer.
-  MIXED_EXPORT int mixed_make_segment_generator(enum mixed_generator_type type, uint32_t frequency, uint32_t samplerate, struct mixed_segment *segment);
+  MIXED_EXPORT int mixed_make_segment_generator(enum mixed_generator_type type, float frequency, uint32_t samplerate, struct mixed_segment *segment);
 
   /// A LADSPA plugin segment
   /// 

--- a/src/segments/generator.c
+++ b/src/segments/generator.c
@@ -162,7 +162,7 @@ int generator_segment_set(uint32_t field, void *value, struct mixed_segment *seg
   return 1;
 }
 
-MIXED_EXPORT int mixed_make_segment_generator(enum mixed_generator_type type, uint32_t frequency, uint32_t samplerate, struct mixed_segment *segment){
+MIXED_EXPORT int mixed_make_segment_generator(enum mixed_generator_type type, float frequency, uint32_t samplerate, struct mixed_segment *segment){
   struct generator_segment_data *data = mixed_calloc(1, sizeof(struct generator_segment_data));
   if(!data){
     mixed_err(MIXED_OUT_OF_MEMORY);


### PR DESCRIPTION
https://github.com/Shirakumo/cl-mixed/pull/19 will be necessary to not break `cl-mixed`.