### PR TITLE
Fix const string style issues

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -92,7 +92,7 @@ int load_out_segment(uint32_t samples, struct out **_out){
   long out_samplerate = output_samplerate;
   int out_channels = 2;
   int out_encoding = MPG123_ENC_SIGNED_16;
-  char *out_encname = "signed 16 bit";
+  const char *out_encname = "signed 16 bit";
   uint8_t out_samplesize = 0;
   int out_framesize = 0;
   struct out *out = calloc(1, sizeof(struct out));
@@ -149,7 +149,7 @@ int load_out_segment(uint32_t samples, struct out **_out){
     goto cleanup;
   }
 
-  out_encname = (char *)out123_enc_longname(out_encoding);
+  out_encname = (const char *)out123_enc_longname(out_encoding);
   fprintf(stderr, "Selected: %i channels @ %li Hz, %s %i\n", out_channels, out_samplerate, out_encname);
   
   // Prepare pipeline segments
@@ -209,11 +209,11 @@ void free_mp3(struct mp3 *mp3){
   free(mp3);
 }
 
-int load_mp3_segment(char *file, uint32_t samples, struct mp3 **_mp3){
+int load_mp3_segment(const char *file, uint32_t samples, struct mp3 **_mp3){
   long mp3_samplerate = 0;
   int mp3_channels = 0;
   int mp3_encoding = 0;
-  char *mp3_encname = 0;
+  const char *mp3_encname = 0;
   uint8_t mp3_samplesize = 0;
   struct mp3 *mp3 = calloc(1, sizeof(struct mp3));
 
@@ -244,7 +244,7 @@ int load_mp3_segment(char *file, uint32_t samples, struct mp3 **_mp3){
     goto cleanup;
   }
   
-  mp3_encname = (char *)out123_enc_longname(mp3_encoding);
+  mp3_encname = (const char *)out123_enc_longname(mp3_encoding);
   fprintf(stderr, "MP3: %i channels @ %li Hz, %s\n", mp3_channels, mp3_samplerate, mp3_encname);
 
   mp3->pack.encoding = fmt123_to_mixed(mp3_encoding);

--- a/examples/meta.c
+++ b/examples/meta.c
@@ -7,7 +7,7 @@
     *target = p;                                \
   }
 
-int parse_arg(int type, void **target, char *in){
+int parse_arg(int type, void **target, const char *in){
   switch(type){
   case MIXED_INT8:
     DECODE_INT(int8_t) break;

--- a/src/common.c
+++ b/src/common.c
@@ -80,7 +80,7 @@ MIXED_EXPORT int mixed_error(void){
   return errorcode;
 }
 
-MIXED_EXPORT char *mixed_error_string(int code){
+MIXED_EXPORT const char *mixed_error_string(int code){
   if(code < 0) code = errorcode;
   switch(code){
   case MIXED_NO_ERROR:
@@ -144,7 +144,7 @@ MIXED_EXPORT char *mixed_error_string(int code){
   }
 }
 
-MIXED_EXPORT char *mixed_type_string(int code){
+MIXED_EXPORT const char *mixed_type_string(int code){
   switch(code){
   case MIXED_UNKNOWN:
     return "unknown";
@@ -217,7 +217,7 @@ MIXED_EXPORT char *mixed_type_string(int code){
   }
 }
 
-MIXED_EXPORT char *mixed_version(void){
+MIXED_EXPORT const char *mixed_version(void){
   return MIXED_VERSION;
 }
 
@@ -237,7 +237,7 @@ void *crealloc(void *ptr, size_t oldcount, size_t newcount, size_t size){
   return ptr;
 }
 
-void set_info_field(struct mixed_segment_field_info *info, uint32_t field, enum mixed_segment_field_type type, uint32_t count, enum mixed_segment_info_flags flags, char*description){
+void set_info_field(struct mixed_segment_field_info *info, uint32_t field, enum mixed_segment_field_type type, uint32_t count, enum mixed_segment_info_flags flags, const char*description){
   info->field = field;
   info->description = description;
   info->flags = flags;
@@ -253,7 +253,7 @@ void clear_info_field(struct mixed_segment_field_info *info){
   info->type_count = 0;
 }
 
-void *open_library(char *file){
+void *open_library(const char *file){
 #ifdef _WIN32
   void *lib = LoadLibrary(file);
   if(!lib){
@@ -288,7 +288,7 @@ void close_library(void *handle){
 #endif
 }
 
-void *load_symbol(void *handle, char *name){
+void *load_symbol(void *handle, const char *name){
 #ifdef _WIN32
   void *function = GetProcAddress(handle, "mixed_make_plugin");
   if(!function){

--- a/src/internal.h
+++ b/src/internal.h
@@ -155,11 +155,11 @@ void mixed_err(int errorcode);
 
 void *crealloc(void *ptr, size_t oldcount, size_t newcount, size_t size);
 
-void *open_library(char *file);
+void *open_library(const char *file);
 void close_library(void *handle);
-void *load_symbol(void *handle, char *name);
+void *load_symbol(void *handle, const char *name);
 
-void set_info_field(struct mixed_segment_field_info *info, uint32_t field, enum mixed_segment_field_type type, uint32_t count, enum mixed_segment_info_flags flags, char*description);
+void set_info_field(struct mixed_segment_field_info *info, uint32_t field, enum mixed_segment_field_type type, uint32_t count, enum mixed_segment_info_flags flags, const char*description);
 void clear_info_field(struct mixed_segment_field_info *info);
 
 float mixed_random(void);

--- a/src/mixed.h
+++ b/src/mixed.h
@@ -780,7 +780,7 @@ extern "C" {
     uint32_t field;
     /// A human-readable description of the data accessed.
     /// 
-    char *description;
+    const char *description;
     /// An OR-combination of flags that describe the field's
     /// properties, usually about whether it is valid for
     /// inputs, outputs, or the segment itself, and whether
@@ -1300,7 +1300,7 @@ extern "C" {
   /// requires you to stop mixing before being able to change any property
   /// but some plugins may nevertheless work despite that. Thus, consult
   /// your plugin's source or documentation.
-  MIXED_EXPORT int mixed_make_segment_ladspa(char *file, uint32_t index, uint32_t samplerate, struct mixed_segment *segment);
+  MIXED_EXPORT int mixed_make_segment_ladspa(const char *file, uint32_t index, uint32_t samplerate, struct mixed_segment *segment);
 
   /// A space (3D) processed mixer
   ///
@@ -1559,12 +1559,12 @@ extern "C" {
   ///
   /// The plugin should call this function to describe its segment names and
   /// construction argument types, along with the actual function to call.
-  typedef int (*mixed_register_segment_function)(char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function);
+  typedef int (*mixed_register_segment_function)(const char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function);
 
   /// Function prototype for a plugin's segment type deregistration function.
   ///
   /// The plugin should call this to deregister a segment it previously registered.
-  typedef int (*mixed_deregister_segment_function)(char *name);
+  typedef int (*mixed_deregister_segment_function)(const char *name);
 
   /// If you write a segment plugin library, you must define an
   /// exported function of this signature named mixed_make_plugin.
@@ -1585,14 +1585,14 @@ extern "C" {
   /// function, or that function fails for some reason.
   /// The file name is copied and may be deallocated again after this
   /// function has been called.
-  MIXED_EXPORT int mixed_load_plugin(char *file);
+  MIXED_EXPORT int mixed_load_plugin(const char *file);
 
   /// Close an existing plugin library.
   ///
   /// This function may fail if the requested library was not loaded before,
   /// it does not contain the required mixed_free_plugin function, or that
   /// function fails for some reason.
-  MIXED_EXPORT int mixed_close_plugin(char *file);
+  MIXED_EXPORT int mixed_close_plugin(const char *file);
 
   /// The maximum number of arguments that can be passed to a segment constructor
 #define MIXED_MAX_MAKE_ARG_COUNT 32
@@ -1614,12 +1614,12 @@ extern "C" {
   /// is errored.
   /// If there are no more free segments available to register, MIXED_OUT_OF_MEMORY
   /// is errored.
-  MIXED_EXPORT int mixed_register_segment(char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function);
+  MIXED_EXPORT int mixed_register_segment(const char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function);
 
   /// Remove a globally registered segment constructor.
   ///
   /// If successful, the given name can be registered again afterwards.
-  MIXED_EXPORT int mixed_deregister_segment(char *name);
+  MIXED_EXPORT int mixed_deregister_segment(const char *name);
 
   /// List available segments.
   ///
@@ -1632,14 +1632,14 @@ extern "C" {
   /// argc will be set to the number of required arguments, and
   /// args will be set to an array of segment_field_info structures of
   /// that size describing the required arguments.
-  MIXED_EXPORT int mixed_make_segment_info(char *name, uint32_t *argc, const struct mixed_segment_field_info **args);
+  MIXED_EXPORT int mixed_make_segment_info(const char *name, uint32_t *argc, const struct mixed_segment_field_info **args);
 
   /// Create a segment by name.
   ///
   /// args must be an array of pointers, where each pointer in the array
   /// points to a value of the type as described in the respective
   /// segment_field_info structure for the constructor.
-  MIXED_EXPORT int mixed_make_segment(char *name, void *args, struct mixed_segment *segment);
+  MIXED_EXPORT int mixed_make_segment(const char *name, void *args, struct mixed_segment *segment);
 
   /// Return the size of a sample in the given encoding in bytes.
   /// 
@@ -1717,15 +1717,15 @@ extern "C" {
   ///
   /// If the error code is less than zero, the error string for the
   /// error code returned by mixed_error(); is returned instead.
-  MIXED_EXPORT char *mixed_error_string(int error_code);
+  MIXED_EXPORT const char *mixed_error_string(int error_code);
 
   /// Return the ASCII textual description of the given type identifier.
   ///
-  MIXED_EXPORT char *mixed_type_string(int code);
+  MIXED_EXPORT const char *mixed_type_string(int code);
 
   /// Returns the ASCII version string of the library.
   ///
-  MIXED_EXPORT char *mixed_version(void);
+  MIXED_EXPORT const char *mixed_version(void);
 
   //// Allow customising how libmixed allocates things.
 #ifdef MIXED_NO_CUSTOM_ALLOCATOR

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -26,7 +26,7 @@ struct segment_vector{
 struct plugin_vector plugins = {0};
 struct segment_vector segments = {0};
 
-MIXED_EXPORT int mixed_load_plugin(char *file){
+MIXED_EXPORT int mixed_load_plugin(const char *file){
   struct plugin_entry *entry = 0;
   void *handle = 0;
   uint32_t length = strlen(file);
@@ -72,7 +72,7 @@ MIXED_EXPORT int mixed_load_plugin(char *file){
   return 0;
 }
 
-MIXED_EXPORT int mixed_close_plugin(char *file){
+MIXED_EXPORT int mixed_close_plugin(const char *file){
   for(uint32_t i=0; i<plugins.count; ++i){
     struct plugin_entry *entry = plugins.entries[i];
     if(strcmp(entry->file, file) == 0){
@@ -94,7 +94,7 @@ MIXED_EXPORT int mixed_close_plugin(char *file){
   return 0;
 }
 
-MIXED_EXPORT int mixed_register_segment(char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function){
+MIXED_EXPORT int mixed_register_segment(const char *name, uint32_t argc, struct mixed_segment_field_info *args, mixed_make_segment_function function){
   struct segment_entry *entry = 0;
 
   if(MIXED_MAX_MAKE_ARG_COUNT < argc){
@@ -136,7 +136,7 @@ MIXED_EXPORT int mixed_register_segment(char *name, uint32_t argc, struct mixed_
   return 1;
 }
 
-MIXED_EXPORT int mixed_deregister_segment(char *name){
+MIXED_EXPORT int mixed_deregister_segment(const char *name){
   for(uint32_t i=0; i<segments.count; ++i){
     struct segment_entry *entry = &segments.entries[i];
     if(entry->function && strcmp(entry->name, name) == 0){
@@ -162,7 +162,7 @@ MIXED_EXPORT int mixed_list_segments(uint32_t *count, char **names){
   return 1;
 }
 
-MIXED_EXPORT int mixed_make_segment_info(char *name, uint32_t *argc, const struct mixed_segment_field_info **args){
+MIXED_EXPORT int mixed_make_segment_info(const char *name, uint32_t *argc, const struct mixed_segment_field_info **args){
   for(uint32_t i=0; i<segments.count; ++i){
     struct segment_entry *entry = &segments.entries[i];
     if(entry->function && strcmp(entry->name, name) == 0){
@@ -175,7 +175,7 @@ MIXED_EXPORT int mixed_make_segment_info(char *name, uint32_t *argc, const struc
   return 0;
 }
 
-MIXED_EXPORT int mixed_make_segment(char *name, void *args, struct mixed_segment *segment){
+MIXED_EXPORT int mixed_make_segment(const char *name, void *args, struct mixed_segment *segment){
   for(uint32_t i=0; i<segments.count; ++i){
     struct segment_entry *entry = &segments.entries[i];
     if(entry->function && strcmp(entry->name, name) == 0){

--- a/src/segments/ladspa.c
+++ b/src/segments/ladspa.c
@@ -208,7 +208,7 @@ int ladspa_segment_set(uint32_t field, void *value, struct mixed_segment *segmen
   return 0;
 }
 
-int ladspa_load_descriptor(char *file, uint32_t index, LADSPA_Descriptor **_descriptor){
+int ladspa_load_descriptor(const char *file, uint32_t index, LADSPA_Descriptor **_descriptor){
   LADSPA_Descriptor_Function descriptor_function;
   const LADSPA_Descriptor *descriptor;
 
@@ -232,7 +232,7 @@ int ladspa_load_descriptor(char *file, uint32_t index, LADSPA_Descriptor **_desc
   return 0;
 }
 
-MIXED_EXPORT int mixed_make_segment_ladspa(char *file, uint32_t index, uint32_t samplerate, struct mixed_segment *segment){
+MIXED_EXPORT int mixed_make_segment_ladspa(const char *file, uint32_t index, uint32_t samplerate, struct mixed_segment *segment){
   struct ladspa_segment_data *data = 0;
 
   data = mixed_calloc(1, sizeof(struct ladspa_segment_data));
@@ -285,7 +285,7 @@ MIXED_EXPORT int mixed_make_segment_ladspa(char *file, uint32_t index, uint32_t 
 }
 
 int __make_ladspa(void *args, struct mixed_segment *segment){
-  return mixed_make_segment_ladspa(ARG(char *, 0), ARG(uint32_t, 1), ARG(uint32_t, 2), segment);
+  return mixed_make_segment_ladspa(ARG(const char *, 0), ARG(uint32_t, 1), ARG(uint32_t, 2), segment);
 }
 
 REGISTER_SEGMENT(ladspa, __make_ladspa, 3, {


### PR DESCRIPTION
The existing API was confusing and communicated inconsistent and inaccurate expectations regarding either the mutability of strings returned by functions or the possibility of strings passed to functions being mutated. Hopefully I fixed all of the instances of this issue.